### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/LLCD.CourseExtractor.Tests/LLCD.CourseExtractor.Tests.csproj
+++ b/LLCD.CourseExtractor.Tests/LLCD.CourseExtractor.Tests.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="ObjectDumper.NET" Version="3.0.20251.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1" />
+    <PackageReference Include="ObjectDumper.NET" Version="3.1.21178.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@ahmedayman4a, I found an issue in the LLCD.CourseExtractor.Tests.csproj:

Packages Microsoft.NET.Test.Sdk v16.5.0, MSTest.TestAdapter v2.1.0, MSTest.TestFramework v2.1.0, coverlet.collector v1.2.0 and ObjectDumper.NET v3.0.20251.1 transitively introduce 78 dependencies into Linkedin-Learning-Courses-Downloader’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Linkedin-Learning-Courses-Downloader.html)), while Microsoft.NET.Test.Sdk v16.8.3, MSTest.TestAdapter v2.2.1, MSTest.TestFramework v2.1.1, coverlet.collector v1.2.1 and ObjectDumper.NET v3.1.21178.1 can only introduce 49 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Linkedin-Learning-Courses-Downloader_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose